### PR TITLE
Add AVX512 subsets up to "AVX3.2"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Output is detailed as follows:
 | Name       | Name of the CPU   | Any valid CPU name |
 | Frequency  | Max frequency of the CPU(in GHz) | X.XX(GHz or MHz)
 | N.Cores    | Number of cores the CPU has. If CPU supports `Hyperthreading` or similar, this will show cores and threads separately | X(cores)X(threads)
-| AVX        | Type of AVX supported by the CPU or None. AVX instructions allows the CPU to vectorize the code with a witdh of 256 bits in single precision(or 512bits if AVX512 is supported) | AVX,AVX2,AVX512,None
+| AVX        | Type of AVX supported by the CPU or None. AVX instructions allows the CPU to vectorize the code with a witdh of 256 bits in single precision(or 512bits if AVX512 is supported) | AVX,AVX2,AVX512(F,PF,ER,CD,etc),None
 | SSE        | Same as AVX, but SSE family are 128bits witdh | SSE, SSE2, SSE3, SSSE3, SSE4a, SSE4_1, SSE4_2,None |
 | FMA        | Does this CPU support FMA(Fused Multiply Add)?This instruction allows the CPU to multiply and add a value on the same clock cycle | FMA3,FMA4,None |
 | AES        | Does this CPU support AES? This instruction is allows the CPU to make AES cypher efficiently | Yes or No |

--- a/src/standart.c
+++ b/src/standart.c
@@ -192,10 +192,19 @@ struct cpuInfo* getCPUInfo() {
     cpu->AVX512DQ     = ((ebx & ((int)1 << 17)) != 0);
     cpu->AVX512BW     = ((ebx & ((int)1 << 30)) != 0);
 
-    //                    ((ebx & ((int)1 << 31)) != 0) ||
-    //                    ((ebx & ((int)1 << 30)) != 0) ||
-    //                    ((ebx & ((int)1 << 17)) != 0) ||
-    //                    ((ebx & ((int)1 << 21)) != 0));
+    // ((ebx & ((int)1 << 21)) != 0); //AVX512IMFA
+    // ((ecx & ((int)1 <<  1)) != 0); //AVX512VBMI
+    // ((ecx & ((int)1 <<  6)) != 0); //AVX512VBMI2
+    // ((ecx & ((int)1 <<  8)) != 0); //GFNI
+    // ((ecx & ((int)1 <<  9)) != 0); //VAES
+    // ((ecx & ((int)1 << 10)) != 0); //VPCLMULQDQ
+    // ((ecx & ((int)1 << 11)) != 0); //AVX512VNNI
+    // ((ecx & ((int)1 << 12)) != 0); //AVX512BITALG
+    // ((ecx & ((int)1 << 14)) != 0); //AVX512VPOPCNTDQ
+    // ((edx & ((int)1 <<  8)) != 0); //AVX512VP2INTERSECT
+    // ecx = 0x00000001;
+    // cpuid(&eax, &ebx, &ecx, &edx);
+    // ((eax & ((int)1 <<  5)) != 0); //AVX512BF16
   }
   if (cpu->maxExtendedLevels >= 0x80000001){
       eax = 0x80000001;
@@ -304,31 +313,31 @@ char* getString_NumberCores(struct cpuInfo* cpu) {
 }
 
 char* getString_AVX(struct cpuInfo* cpu) {
-  //If all AVX are available, it will use up to 15
   char* string = malloc(sizeof(char)*128);
   memset(string, 0, 128);
-  char* curend = string;
+  char* last = string;
   if(cpu->AVX == BOOLEAN_TRUE)
-    curend += sprintf(curend,"AVX,");
+    last += sprintf(last,"AVX,");
   if(cpu->AVX2 == BOOLEAN_TRUE)
-    curend += sprintf(curend,"AVX2,");
+    last += sprintf(last,"AVX2,");
   if(cpu->AVX512F == BOOLEAN_TRUE)
-    curend += sprintf(curend,"AVX512F,");
+    last += sprintf(last,"AVX512F,");
   if(cpu->AVX512PF == BOOLEAN_TRUE)
-    curend += sprintf(curend,"AVX512PF,");
+    last += sprintf(last,"AVX512PF,");
   if(cpu->AVX512ER == BOOLEAN_TRUE)
-    curend += sprintf(curend,"AVX512ER,");
+    last += sprintf(last,"AVX512ER,");
   if(cpu->AVX512CD == BOOLEAN_TRUE)
-    curend += sprintf(curend,"AVX512CD,");
+    last += sprintf(last,"AVX512CD,");
 
   if(cpu->AVX512VL == BOOLEAN_TRUE)
-    curend += sprintf(curend,"AVX512VL,");
+    last += sprintf(last,"AVX512VL,");
   if(cpu->AVX512DQ == BOOLEAN_TRUE)
-    curend += sprintf(curend,"AVX512DQ,");
+    last += sprintf(last,"AVX512DQ,");
   if(cpu->AVX512BW == BOOLEAN_TRUE)
-    curend += sprintf(curend,"AVX512BW,");
+    last += sprintf(last,"AVX512BW,");
 
-  if(curend > string) *(curend - 1) = 0;
+  // Remove trailing comma
+  if(last > string) *(last - 1) = 0;
   return string;
 }
 

--- a/src/standart.c
+++ b/src/standart.c
@@ -328,7 +328,7 @@ char* getString_AVX(struct cpuInfo* cpu) {
   if(cpu->AVX512BW == BOOLEAN_TRUE)
     curend += sprintf(curend,"AVX512BW,");
 
-  *(curend - 1) = 0;
+  if(curend > string) *(curend - 1) = 0;
   return string;
 }
 


### PR DESCRIPTION
["Formerly, the term AVX3.2 referred to F + CD + BW + DQ + VL"](https://en.wikichip.org/wiki/x86/avx-512)

This implements the AVX512 subsets implemented up to Skylake-X.

Here's the output on my i9-7900x.

```
                              ################                
                      #######                #######          
                 ####                              ####       
             ###                                     ####     
        ###                                             ###   Name:       Intel(R) Core(TM) i9-7900X CPU @ 3.30GHz
        ###                                             ###   Frequency:  4.50GHz
     #                    ###                ###        ###   N.Cores:    10 cores(20 threads)
   ##   ###   #########   ######   ######    ###        ###   AVX:        AVX,AVX2,AVX512F,AVX512CD,AVX512VL,AVX512DQ,AVX512BW
  ##    ###   ###    ###  ###    ####  ####  ###        ###   SSE:        SSE,SSE2,SSE3,SSSE3,SSE4_1,SSE4_2
 ##     ###   ###    ###  ###    ###    ###  ###       ###    FMA:        FMA3
##      ###   ###    ###  ###    ##########  ###     ####     AES:        Yes
##      ###   ###    ###  ###    ###         ###   #####      SHA:        No
##       ##   ###    ###   #####  #########   ##  ###         L1 Size:    32KB(Data)32KB(Instructions)
###                                                           L2 Size:    1024KB
 ###                                                          L3 Size:    14080K
 ####                                        ####             Peak FLOPS: 2.88 TFLOP/s
   #####                               ##########             
     ##########               ################                
         ###############################                      
                                              
```