### PR TITLE
fixed cpu->VENDOR error

### DIFF
--- a/src/standart.c
+++ b/src/standart.c
@@ -436,7 +436,7 @@ char* get_str_peak_performance(struct cpuInfo* cpu, struct topology* topo, long 
   
   // Intel USUALLY has two VPUs. I have never seen an AMD 
   // with two VPUs.
-  if(cpu->VENDOR == VENDOR_INTEL) flops = flops * 2; 
+  if(cpu->cpu_vendor == VENDOR_INTEL) flops = flops * 2; 
 
   if(cpu->FMA3 || cpu->FMA4)
     flops = flops*2;


### PR DESCRIPTION
This error was preventing the code from being built. VENDOR is a typedef of int, not a member of the cpuInfo struct. The intended member to be accessed is cpu_vendor.