### PR TITLE
Implement VT100 escape-codes for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ cpufetch currently supports x86 CPUs (both Intel and AMD CPUs)
 | Platform  | Intel                     | AMD                      | Notes             |
 |:---------:|:-------------------------:|:------------------------:|:-----------------:|
 | Linux     | :heavy_check_mark:        | :heavy_check_mark:       | Prefered platform |
-| Windows   | :heavy_check_mark:        | :heavy_check_mark:       | Some information may be missing. <br> No colors and worse CPU art |
+| Windows   | :heavy_check_mark:        | :heavy_check_mark:       | Some information may be missing. <br> Colors will be used if supported |
 | macOS     | :heavy_exclamation_mark:  | :heavy_exclamation_mark: | Untested |
 
 

--- a/src/printer.c
+++ b/src/printer.c
@@ -166,16 +166,21 @@ struct ascii* set_ascii(VENDOR cpuVendor, STYLE style, struct colors* cs) {
   }
   art->ascii_chars[1] = '#';
 
+  #ifdef _WIN32
+    HANDLE std_handle = GetStdHandle(STD_OUTPUT_HANDLE);
+    DWORD console_mode;
+    
+    // Attempt to enable the VT100-processing flag
+    GetConsoleMode(std_handle, &console_mode);
+    SetConsoleMode(std_handle, console_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+    // Get the console mode flag again, to see if it successfully enabled it
+    GetConsoleMode(std_handle, &console_mode);
+  #endif
+    
   if(style == STYLE_EMPTY) {
     #ifdef _WIN32
-      HANDLE std_handle = GetStdHandle(STD_OUTPUT_HANDLE);
-      DWORD console_mode;
-      // Attempt to enable the VT100-processing flag
-      GetConsoleMode(std_handle, &console_mode);
-      SetConsoleMode(std_handle, console_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
-      // Get the console mode flag again, to see if it successfully enabled it
-      GetConsoleMode(std_handle, &console_mode);
-      // Enable fancy mode if VT100-processing is enabled
+      // Use fancy style if VT100-processing is enabled,
+      // or legacy style in other case
       art->style = (console_mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING) ? STYLE_FANCY : STYLE_LEGACY;
     #else
       art->style = STYLE_FANCY;


### PR DESCRIPTION
Latest versions of Windows have support for the parsing of VT100 escape
code sequences, allowing for terminal colors similar to Linux.

This is supported since around **Windows 10 Build 10586** and later.

https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#screen-colors

Here I have it get the console mode, set the
`ENABLE_VIRTUAL_TERMINAL_PROCESSING` flag, and then grab the console
mode again to both verify that VT100 escape sequences are supported and
that it is enabled after setting it to determine if the printer should
allow for fancy-color mode. This should allow it to be backwards compatible with systems that do not support this flag as it will not preserve this console mode if not supported.

This allows for terminal-colors to be detected and used on windows. Can verify that it works on my machine with mingw but it will need some more testing.

![image](https://user-images.githubusercontent.com/644247/96181352-b6fa7180-0ee8-11eb-93a0-b101c193ad95.png)
