### PR TITLE
User can install in PREFIX root folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,14 @@ SRC_COMMON=src/common/
 COMMON_SRC = $(SRC_COMMON)main.c $(SRC_COMMON)cpu.c $(SRC_COMMON)udev.c $(SRC_COMMON)printer.c $(SRC_COMMON)args.c $(SRC_COMMON)global.c
 COMMON_HDR = $(SRC_COMMON)ascii.h $(SRC_COMMON)cpu.h $(SRC_COMMON)udev.h $(SRC_COMMON)printer.h $(SRC_COMMON)args.h $(SRC_COMMON)global.h
 
+PREFIX = /usr/local
+
 ifneq ($(OS),Windows_NT)
 	arch := $(shell uname -m)
 	ifeq ($(arch), x86_64)
 		SRC_DIR=src/x86/
 		SOURCE += $(COMMON_SRC) $(SRC_DIR)cpuid.c $(SRC_DIR)apic.c $(SRC_DIR)cpuid_asm.c $(SRC_DIR)uarch.c
-		HEADERS += $(COMMON_HDR) $(SRC_DIR)cpuid.h $(SRC_DIR)apic.h $(SRC_DIR)cpuid_asm.h $(SRC_DIR)uarch.h 
+		HEADERS += $(COMMON_HDR) $(SRC_DIR)cpuid.h $(SRC_DIR)apic.h $(SRC_DIR)cpuid_asm.h $(SRC_DIR)uarch.h
 		CXXFLAGS += -DARCH_X86
 	else
 		SRC_DIR=src/arm/
@@ -22,12 +24,12 @@ ifneq ($(OS),Windows_NT)
 		CXXFLAGS += -DARCH_ARM -Wno-unused-parameter
 	endif
 
-	OUTPUT=cpufetch
+	OUTPUT= $(PREFIX)/bin/cpufetch
 else
 	# Assume x86_64
 	SRC_DIR=src/x86/
 	SOURCE += $(COMMON_SRC) $(SRC_DIR)cpuid.c $(SRC_DIR)apic.c $(SRC_DIR)cpuid_asm.c $(SRC_DIR)uarch.c
-	HEADERS += $(COMMON_HDR) $(SRC_DIR)cpuid.h $(SRC_DIR)apic.h $(SRC_DIR)cpuid_asm.h $(SRC_DIR)uarch.h 
+	HEADERS += $(COMMON_HDR) $(SRC_DIR)cpuid.h $(SRC_DIR)apic.h $(SRC_DIR)cpuid_asm.h $(SRC_DIR)uarch.h
 	CXXFLAGS += -DARCH_X86
 	SANITY_FLAGS += -Wno-pedantic-ms-format
 	OUTPUT=cpufetch.exe
@@ -51,6 +53,6 @@ clean:
 	@rm $(OUTPUT)
 
 install: $(OUTPUT)
-	install -Dm755 "cpufetch"   "/usr/bin/cpufetch"
-	install -Dm644 "LICENSE"    "/usr/share/licenses/cpufetch-git/LICENSE"
-	install -Dm644 "cpufetch.8" "/usr/share/man/man8/cpufetch.8.gz"
+	install -Dm755 "cpufetch"   "$(PREFIX)/bin/cpufetch"
+	install -Dm644 "LICENSE"    "$(PREFIX)/share/licenses/cpufetch-git/LICENSE"
+	install -Dm644 "cpufetch.8" "$(PREFIX)/share/man/man8/cpufetch.8.gz"


### PR DESCRIPTION
Hi,

Users can't choose what root folder to install the binary.

On Linux Distro is either `/usr/local/` or `$HOME/.local` , that's why it's optimal to let user choose it.


Changes in `Makefile`:
- Add PREFIX env variable
- install commands use PREFIX

Reproduce:
` make PREFIX=$HOME/.local`

PS: `/usr/bin/` is a folder reserved for Distro repositories packages. `/usr/local` is meant for local builds, the same goes for `$HOME/.local` for non-root users.

:)