### PR TITLE
Added support for L4 cache detection.

### DIFF
--- a/src/arm/midr.c
+++ b/src/arm/midr.c
@@ -20,6 +20,7 @@ void init_cache_struct(struct cache* cach) {
   cach->L1d = malloc(sizeof(struct cach));
   cach->L2 = malloc(sizeof(struct cach));
   cach->L3 = malloc(sizeof(struct cach));
+  cach->L4 = malloc(sizeof(struct cach));
 
   cach->cach_arr = malloc(sizeof(struct cach*) * 4);
   cach->cach_arr[0] = cach->L1i;
@@ -32,6 +33,7 @@ void init_cache_struct(struct cache* cach) {
   cach->L1d->exists = false;
   cach->L2->exists = false;
   cach->L3->exists = false;
+  cach->L4->exists = false;
 }
 
 struct cache* get_cache_info(struct cpuInfo* cpu) { 

--- a/src/common/cpu.c
+++ b/src/common/cpu.c
@@ -145,6 +145,12 @@ char* get_str_l3(struct cache* cach) {
   return get_str_cache(cach->L3->size, cach->L3->num_caches);
 }
 
+char* get_str_l4(struct cache* cach) {
+  if(!cach->L4->exists)
+    return NULL;  
+  return get_str_cache(cach->L4->size, cach->L4->num_caches);
+}
+
 char* get_str_freq(struct frequency* freq) {
   //Max 3 digits and 3 for '(M/G)Hz' plus 1 for '\0'
   uint32_t size = (5+1+3+1);

--- a/src/common/cpu.h
+++ b/src/common/cpu.h
@@ -61,6 +61,7 @@ struct cache {
   struct cach* L1d;
   struct cach* L2;
   struct cach* L3;
+  struct cach* L4;
   struct cach** cach_arr;
 
   uint8_t max_cache_level;
@@ -149,6 +150,7 @@ char* get_str_l1i(struct cache* cach);
 char* get_str_l1d(struct cache* cach);
 char* get_str_l2(struct cache* cach);
 char* get_str_l3(struct cache* cach);
+char* get_str_l4(struct cache* cach);
 char* get_str_freq(struct frequency* freq);
 
 void free_cache_struct(struct cache* cach);

--- a/src/common/printer.c
+++ b/src/common/printer.c
@@ -68,6 +68,7 @@ enum {
   ATTRIBUTE_L1d,
   ATTRIBUTE_L2,
   ATTRIBUTE_L3,
+  ATTRIBUTE_L4,
   ATTRIBUTE_PEAK
 };
 
@@ -95,6 +96,7 @@ static const char* ATTRIBUTE_FIELDS [] = {
   "L1d Size:",
   "L2 Size:",
   "L3 Size:",
+  "L4 Size:",
   "Peak Performance:",
 };
 
@@ -441,6 +443,7 @@ bool print_cpufetch_x86(struct cpuInfo* cpu, STYLE s, struct colors* cs) {
   char* l1d = get_str_l1d(cpu->cach);
   char* l2 = get_str_l2(cpu->cach);
   char* l3 = get_str_l3(cpu->cach);
+  char* l4 = get_str_l4(cpu->cach);
   char* pp = get_str_peak_performance(cpu,cpu->topo,get_freq(cpu->freq));
 
   setAttribute(art,ATTRIBUTE_NAME,cpu_name);
@@ -466,6 +469,9 @@ bool print_cpufetch_x86(struct cpuInfo* cpu, STYLE s, struct colors* cs) {
   setAttribute(art,ATTRIBUTE_L2,l2);
   if(l3 != NULL) {
     setAttribute(art,ATTRIBUTE_L3,l3);
+  }
+  if(l4 != NULL) {
+    setAttribute(art,ATTRIBUTE_L4,l4);
   }
   setAttribute(art,ATTRIBUTE_PEAK,pp);
   


### PR DESCRIPTION
Added support for L4 cache to stop segfaulting on Broadwell with 128 MB eDRAM L4 cache.

Will fix this issue:
$ ./cpufetch 
[ERROR]: Found unified cache at level 4 (expected == 2 or 3)
Please, create a new issue with this error message and the output of 'cpufetch --debug' in https://github.com/Dr-Noob/cpufetch/issues
Segmentation fault (core dumped)
                                                              
                                                              Name:              Intel(R) Core(TM) i7-5775C CPU @ 3.30GHz
                                                              Microarchitecture: Broadwell
                                                              Technology:        14nm
                                                              Max Frequency:     4.101 GHz
                                                              Cores:             4 cores (8 threads)
                                                              AVX:               AVX,AVX2
                                                              FMA:               FMA3
                                                              L1i Size:          32KB (128KB Total)
                                                              L1d Size:          32KB (128KB Total)
                                                              L2 Size:           256KB (1MB Total)
                                                              L3 Size:           6MB
                                                              L4 Size:           128MB
                                                              Peak Performance:  524.93 GFLOP/s
                                                              
                                                              
                                                              
