### PR TITLE
Fix Windows build

### DIFF
--- a/src/x86/apic.c
+++ b/src/x86/apic.c
@@ -1,4 +1,5 @@
 #ifdef _WIN32
+#define NOMINMAX
 #include <windows.h>
 #elif defined __linux__
 #define _GNU_SOURCE

--- a/src/x86/cpuid.c
+++ b/src/x86/cpuid.c
@@ -1,4 +1,5 @@
 #ifdef _WIN32
+  #define NOMINMAX
   #include <windows.h>
 #else
   #include "../common/udev.h"


### PR DESCRIPTION
`windows.h` defines `max` as a macro and this conflicts with `max` defined in global.h.