### PR TITLE
Make sure topo->apic is always initialized

### DIFF
--- a/src/x86/cpuid.c
+++ b/src/x86/cpuid.c
@@ -58,6 +58,7 @@ void init_topology_struct(struct topology* topo, struct cache* cach) {
   topo->smt_supported = 0;
   topo->sockets = 0;
   topo->apic = malloc(sizeof(struct apic));
+  memset(topo->apic, 0, sizeof(struct apic));
   topo->cach = cach;
 }
 


### PR DESCRIPTION
Otherwise, `free_topo_struct` might free invalid pointers (namely `cache_select_mask` and `cache_id_apic`). That would happen in case of an AMD CPU, for example.