### PR TITLE
Compile on Mac

### DIFF
--- a/src/common/args.c
+++ b/src/common/args.c
@@ -192,11 +192,13 @@ char* build_short_options() {
 #ifdef ARCH_X86
   sprintf(str, "%c%c:%c:%c%c%c%c",
   c[ARG_RAW],
-#else
-  sprintf(str, "%c:%c:%c%c%c%c",
-#endif
   c[ARG_STYLE], c[ARG_COLOR], c[ARG_HELP],
   c[ARG_DEBUG], c[ARG_VERBOSE], c[ARG_VERSION]);
+#else
+  sprintf(str, "%c:%c:%c%c%c%c",
+  c[ARG_STYLE], c[ARG_COLOR], c[ARG_HELP],
+  c[ARG_DEBUG], c[ARG_VERBOSE], c[ARG_VERSION]);
+#endif
 
   return str;
 }


### PR DESCRIPTION
**Fixes this error:**

```sh
gcc -Wall -Wextra -Werror -pedantic -fstack-protector-all -pedantic -std=c99 -DARCH_X86 -Wfloat-equal -Wshadow -Wpointer-arith src/common/main.c src/common/cpu.c src/common/udev.c src/common/printer.c src/common/args.c src/common/global.c src/x86/cpuid.c src/x86/apic.c src/x86/cpuid_asm.c src/x86/uarch.c -o cpufetch
src/common/args.c:195:2: error: embedding a directive within macro arguments has undefined behavior
      [-Werror,-Wembedded-directive]
#else
 ^
1 error generated.
make: *** [cpufetch] Error 1
```