### PR TITLE
Enable checking some buffer overflows at runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC ?= gcc
 
-CFLAGS+=-Wall -Wextra -pedantic -fstack-protector-all -pedantic -std=c99
+CFLAGS+=-D_FORTIFY_SOURCE=2 -Wall -Wextra -pedantic -fstack-protector-all -pedantic -std=c99
 SANITY_FLAGS=-Wfloat-equal -Wshadow -Wpointer-arith
 
 PREFIX ?= /usr


### PR DESCRIPTION
This change makes the default build similar to what e.g. Debian/Fedora do by default and will allow to catch some potential problems earlier in the dev process