### PR TITLE
Various small fixes

### DIFF
--- a/src/common/cpu.c
+++ b/src/common/cpu.c
@@ -69,14 +69,14 @@ int32_t get_value_as_smallest_unit(char ** str, uint32_t value) {
 
 // String functions 
 char* get_str_cache_two(int32_t cache_size, uint32_t physical_cores) {
-  // 4 for digits, 2 for units, 2 for ' (', 3 digits, 2 for units and 7 for ' Total)'
-  uint32_t max_size = 4+2 + 2 + 4+2 + 7 + 1;
   int32_t sanity_ret;
-  char* string = malloc(sizeof(char) * max_size);  
   char* tmp1 = NULL;
   char* tmp2 = NULL;
   int32_t tmp1_len = get_value_as_smallest_unit(&tmp1, cache_size);
   int32_t tmp2_len = get_value_as_smallest_unit(&tmp2, cache_size * physical_cores);
+  // 4 for digits, 2 for units, 2 for ' (', 3 digits, 2 for units and 7 for ' Total)'
+  uint32_t max_size = tmp1_len + 2 + tmp2_len + 7 + 1;
+  char* string = malloc(sizeof(char) * max_size);
   
   if(!string || !tmp1 || !tmp2) {
     if(tmp1)
@@ -102,8 +102,7 @@ char* get_str_cache_two(int32_t cache_size, uint32_t physical_cores) {
     return NULL;    
   }
     
-  uint32_t size = tmp1_len + 2 + tmp2_len + 7 + 1;
-  sanity_ret = snprintf(string, size, "%s (%s Total)", tmp1, tmp2);  
+  sanity_ret = snprintf(string, max_size, "%s (%s Total)", tmp1, tmp2);
   
   if(sanity_ret < 0) {
     printBug("get_str_cache_two: snprintf returned a negative value for input: '%s' and '%s'\n", tmp1, tmp2);

--- a/src/x86/apic.c
+++ b/src/x86/apic.c
@@ -47,9 +47,8 @@ uint32_t create_mask(uint32_t num_entries, uint32_t *mask_width) {
   }
 
   if (mask_width) *mask_width = i;
-  if (i == 31) return (uint32_t ) -1;
 
-  return (1 << i) -1;
+  return (1ULL << i) -1;
 }
 
 uint32_t get_apic_id(bool x2apic_id) {


### PR DESCRIPTION
- do not leak memory on error conditions
- add checks for malloc returning NULL and fail
- avoid OOB from snprintf with snprintf size > buffer size

The OOB can be seen as the following output:

# ./cpufetch 
*** buffer overflow detected ***: terminated
Aborted
