### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/DOCUMENTATION_ARM.md
+++ b/doc/DOCUMENTATION_ARM.md
@@ -11,7 +11,7 @@ Microarchitecture information is acquired from the Main ID Register (MIDR) [[2](
 - `CPU part`
 - `CPU revision`
 
-The MIDR register can be built with this information. Another posible approach is to read MIDR directly from `/sys/devices/system/cpu/cpu*/regs/identification/midr_el1`
+The MIDR register can be built with this information. Another possible approach is to read MIDR directly from `/sys/devices/system/cpu/cpu*/regs/identification/midr_el1`
 
 With the MIDR available, the approach is the same as the one used in x86_64 architectures. cpufetch has a file that acts like a database that tries to match the MIDR register with the specific CPU microarchitecture.
 

--- a/src/arm/soc.c
+++ b/src/arm/soc.c
@@ -369,7 +369,7 @@ bool match_qualcomm(char* soc_name, struct system_on_chip* soc) {
   SOC_EQ(tmp, "MSM8625Q",       "200",       SOC_SNAPD_MSM8625Q,       soc, 45)
   SOC_EQ(tmp, "MSM8208",        "208",       SOC_SNAPD_MSM8208,        soc, 28)
   SOC_EQ(tmp, "MSM8905",        "205",       SOC_SNAPD_MSM8905,        soc, 28)
-  SOC_EQ(tmp, "MSM8909",        "210 / 212", SOC_SNAPD_MSM8909,        soc, 28) // In the future, we can differenciate them using frequency
+  SOC_EQ(tmp, "MSM8909",        "210 / 212", SOC_SNAPD_MSM8909,        soc, 28) // In the future, we can differentiate them using frequency
   SOC_EQ(tmp, "QM215",          "215",       SOC_SNAPD_QM215,          soc, 28)
   // Snapdragon 4XX //
   SOC_EQ(tmp, "APQ8028",        "400",       SOC_SNAPD_APQ8028,        soc, 28)


### PR DESCRIPTION
There are small typos in:
- doc/DOCUMENTATION_ARM.md
- src/arm/soc.c

Fixes:
- Should read `possible` rather than `posible`.
- Should read `differentiate` rather than `differenciate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md