### PR TITLE
Makefile adjustments for packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ strict: CFLAGS += -O3 -Werror -fsanitize=undefined -D_FORTIFY_SOURCE=2
 strict: $(OUTPUT)
 
 $(OUTPUT): Makefile $(SOURCE) $(HEADERS)
-	$(CC) $(CFLAGS) $(SANITY_FLAGS) $(SOURCE) -o $(OUTPUT)
+	$(CC) $(CFLAGS) $(SANITY_FLAGS) $(SOURCE) -o $(OUTPUT) $(LDFLAGS)
 
 run: $(OUTPUT)
 	./$(OUTPUT)
@@ -73,11 +73,9 @@ clean:
 	@rm -f $(OUTPUT)
 
 install: $(OUTPUT)
-	install -Dm755 "cpufetch"   "$(DESTDIR)$(PREFIX)/bin/cpufetch"
-	install -Dm644 "LICENSE"    "$(DESTDIR)$(PREFIX)/share/licenses/cpufetch-git/LICENSE"
+	install -Dm755 "cpufetch"   -t "$(DESTDIR)$(PREFIX)/bin/"
 	install -Dm644 "cpufetch.1" "$(DESTDIR)$(PREFIX)/share/man/man1/cpufetch.1.gz"
 
 uninstall:
 	rm -f "$(DESTDIR)$(PREFIX)/bin/cpufetch"
-	rm -f "$(DESTDIR)$(PREFIX)/share/licenses/cpufetch-git/LICENSE"
 	rm -f "$(DESTDIR)$(PREFIX)/share/man/man1/cpufetch.1.gz"


### PR DESCRIPTION
tl;dr: this patch makes the Makefile more packager-friendly by removing the LICENSE install and appending LDFLAGS to the build

Hi, I'm the package maintainer for `cpufetch`'s stable package on the AUR (one that doesn't target the master branch).

A user suggested that I submit a patch for the Makefile used in `cpufetch` so that it installs LICENSE to a different directory, however I don't think it should be processing licenses and READMEs at all (that is for package maintainers to figure out :^) ). To my knowledge, not all distros install LICENSE to `/usr/share/licenses/$pkgname`, hence this PR.

This patch also appends LDFLAGS for packagers who use them.