### PR TITLE
fix crash on AMD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 cpufetch
 *.o
+*.exe
+/.cache
+/.vscode
+/compile_commands.json

--- a/src/common/cpu.c
+++ b/src/common/cpu.c
@@ -195,6 +195,7 @@ void init_topology_struct(struct topology* topo, struct cache* cach) {
 #ifdef ARCH_X86
   topo->smt_available = 0;
   topo->apic = emalloc(sizeof(struct apic));
+  memset(topo->apic, 0, sizeof(struct apic));
 #endif
 #endif
 }


### PR DESCRIPTION
This is a fix for the following crash on AMD

```
cpufetch.exe caused an Unknown [0xC0000374] Exception at location 00007FFC021AF349 in module ntdll.dll.

AddrPC           Params
00007FFC021AF349 00007FFC021F762C 0000007897DFFAF0 0000026ED8861560  ntdll.dll!RtlIsZeroMemory+0x119
00007FFC021AF313 00007FFC005FFA30 00007FFC022197F0 0000000000000009  ntdll.dll!RtlIsZeroMemory+0xe3
00007FFC021B8092 0000000000000009 0000000000000000 0000026ED8860000  ntdll.dll!RtlpNtSetValueKey+0x4b2
00007FFC021B837A 0000026ED8860000 0000026ED8860000 0000000000000000  ntdll.dll!RtlpNtSetValueKey+0x79a
00007FFC021BE001 0000000000000074 0000026ED8861560 0000026ED8861570  ntdll.dll!RtlpNtSetValueKey+0x6421
00007FFC020D5B43 0000000000000074 0000026ED8860000 0000026ED88677D0  ntdll.dll!RtlGetCurrentServiceSessionId+0x12f3
00007FFC020D47B1 0000026ED8861660 0000000000000013 0000000000000000  ntdll.dll!RtlFreeHeap+0x51
00007FFC00589C9C 0000026ED88617F8 0000000000000013 0000026ED88616F0  msvcrt.dll!free+0x1c
00007FF6C5207785 0000000000000000 0000026ED8861410 003600D100000060  cpufetch.exe!free_topo_struct+0x15  [C:/src/cpufetch/src/x86/cpuid.c @ 1173]
  1171: 
  1172: void free_topo_struct(struct topology* topo) {
> 1173:   free(topo->apic->cache_select_mask);
  1174:   free(topo->apic->cache_id_apic);
  1175:   free(topo->apic);
00007FF6C520429E 0000026ED8861410 0000000000000000 0000000000000000  cpufetch.exe!print_cpufetch_x86+0x68e  [C:/src/cpufetch/src/common/printer.c @ 653]
   651:   if(cs != NULL) free_colors_struct(cs);
   652:   if(cpu->cach != NULL) free_cache_struct(cpu->cach);
>  653:   if(cpu->topo != NULL) free_topo_struct(cpu->topo);
   654:   free_freq_struct(cpu->freq);
   655:   free_cpuinfo_struct(cpu);
00007FF6C520463F 0000000000000000 00007FF6C5201419 0000000000000008  cpufetch.exe!print_cpufetch+0x2f  [C:/src/cpufetch/src/common/printer.c @ 1090]
  1088: 
  1089: #ifdef ARCH_X86
> 1090:   return print_cpufetch_x86(cpu, s, cs, term, show_full_cpu_name);
  1091: #elif ARCH_PPC
  1092:   return print_cpufetch_ppc(cpu, s, cs, term, show_full_cpu_name);
00007FF6C521A2CF 0000000000000000 000000000000000D 00007FF6C522B308  cpufetch.exe!main+0x8f  [C:/src/cpufetch/src/common/main.c @ 123]
   121:   }
   122: 
>  123:   if(print_cpufetch(cpu, get_style(), get_colors(), show_full_cpu_name())) {
   124:     return EXIT_SUCCESS;
   125:   }
00007FF6C52012EE 0000000000000000 0000000000000000 0000000000000000  cpufetch.exe!__tmainCRTStartup+0x16e  [C:/M/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c @ 267]
00007FF6C5201406 0000000000000000 0000000000000000 0000000000000000  cpufetch.exe!mainCRTStartup+0x16  [C:/M/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c @ 188]
00007FFC00357344 0000000000000000 0000000000000000 0000000000000000  KERNEL32.DLL!BaseThreadInitThunk+0x14
00007FFC021026B1 0000000000000000 0000000000000000 0000000000000000  ntdll.dll!RtlUserThreadStart+0x21
```