### PR TITLE
Add support for Transmeta(TM) Crusoe(TM) CPU

### DIFF
--- a/src/common/ascii.h
+++ b/src/common/ascii.h
@@ -492,6 +492,38 @@ $C1        ###########. ############                 \
 $C1            ################                      \
 $C1                 #######                          "
 
+#define ASCII_TRANSMETA \
+"$C1                                                 \
+$C1                                                  \
+$C1              ###########                         \
+$C1          ###################                     \
+$C1        ########    ############                  \
+$C1       #####               ########               \
+$C1      ####                    #######             \
+$C1     ####          ###########   ######           \
+$C1     ####         ##############   #####          \
+$C1     ####        ######    #######   ####         \
+$C1      ###        #####        #####   ####        \
+$C1      ####       ######        ####    ####       \
+$C1       ####       ######      #####    ####       \
+$C1        ####        ######    ####     ####       \
+$C1         #####        #######         #####       \
+$C1          #####         ##################        \
+$C1           ######          #############          \
+$C1             ######                               \
+$C1               #######                            \
+$C1                 ########                         \
+$C1                    ########                      \
+$C1                        #########                 \
+$C1                           #####################  \
+$C1                                ################# \
+$C1                                                  "
+
+
+
+
+
+
 typedef struct ascii_logo asciiL;
 
 //                        +-----------------------------------------------------------------------------------------------------------------+
@@ -516,6 +548,7 @@ asciiL logo_riscv       = { ASCII_RISCV,       63, 18, false, {C_FG_CYAN, C_FG_Y
 asciiL logo_sifive      = { ASCII_SIFIVE,      48, 19, true,  {C_BG_WHITE, C_BG_BLACK},                       {C_FG_WHITE,   C_FG_BLUE}    };
 asciiL logo_starfive    = { ASCII_STARFIVE,    33, 17, false, {C_FG_WHITE},                                   {C_FG_WHITE,   C_FG_BLUE}    };
 asciiL logo_sipeed      = { ASCII_SIPEED,      41, 16, true,  {C_BG_RED, C_BG_WHITE},                         {C_FG_RED,     C_FG_WHITE}   };
+asciiL logo_transmeta   = { ASCII_TRANSMETA,   50, 24, true,  {C_BG_GREEN},                                   {C_FG_WHITE, C_FG_B_GREEN}   };
 
 // Long variants          | ----------------------------------------------------------------------------------------------------------------|
 asciiL logo_amd_l       = { ASCII_AMD_L,       62, 19, true,  {C_BG_WHITE, C_BG_GREEN},                       {C_FG_WHITE, C_FG_GREEN}     };

--- a/src/common/cpu.c
+++ b/src/common/cpu.c
@@ -175,11 +175,11 @@ char* get_str_peak_performance(int64_t flops) {
   str = ecalloc(max_size, sizeof(char));
 
   if(flopsd >= (double)1000000000000.0)
-    snprintf(str, max_size, "%.2f TFLOP/s", flopsd/1000000000000);
+    snprintf(str, max_size, "%.2f TFLOP/s", (float)flopsd/1000000000000);
   else if(flopsd >= 1000000000.0)
-    snprintf(str, max_size, "%.2f GFLOP/s", flopsd/1000000000);
+    snprintf(str, max_size, "%.2f GFLOP/s", (float)flopsd/1000000000);
   else
-    snprintf(str, max_size, "%.2f MFLOP/s", flopsd/1000000);
+    snprintf(str, max_size, "%.2f MFLOP/s", (float)flopsd/1000000);
 
   return str;
 }

--- a/src/common/cpu.h
+++ b/src/common/cpu.h
@@ -8,6 +8,7 @@ enum {
 // ARCH_X86
   CPU_VENDOR_INTEL,
   CPU_VENDOR_AMD,
+  CPU_VENDOR_TRANSMETA,
 // ARCH_ARM
   CPU_VENDOR_ARM,
   CPU_VENDOR_APPLE,
@@ -82,7 +83,7 @@ struct cache {
 };
 
 struct topology {
-  int32_t total_cores;  
+  int32_t total_cores;
   struct cache* cach;
 #if defined(ARCH_X86) || defined(ARCH_PPC)
   int32_t physical_cores;
@@ -98,7 +99,7 @@ struct topology {
 };
 
 struct features {
-  bool AES; // Must be the first field of features struct!  
+  bool AES; // Must be the first field of features struct!
 #ifdef ARCH_X86
   bool AVX;
   bool AVX2;
@@ -116,11 +117,11 @@ struct features {
 #elif ARCH_PPC
   bool altivec;
 #elif ARCH_ARM
-  bool NEON;  
+  bool NEON;
   bool SHA1;
   bool SHA2;
   bool CRC32;
-#endif  
+#endif
 };
 
 struct extensions {

--- a/src/common/printer.c
+++ b/src/common/printer.c
@@ -357,6 +357,9 @@ void choose_ascii_art(struct ascii* art, struct color** cs, struct terminal* ter
   else if(art->vendor == CPU_VENDOR_AMD) {
     art->art = choose_ascii_art_aux(&logo_amd_l, &logo_amd, term, lf);
   }
+  else if (art->vendor == CPU_VENDOR_TRANSMETA) {
+    art->art = &logo_transmeta;
+  }
   else {
     art->art = &logo_unknown;
   }

--- a/src/x86/uarch.c
+++ b/src/x86/uarch.c
@@ -94,6 +94,8 @@ enum {
   UARCH_TIGER_LAKE,
   UARCH_ALDER_LAKE,
   UARCH_RAPTOR_LAKE,
+  // TRANSMETA //
+  UARCH_CRUSOE,
   // AMD //
   UARCH_AM486,
   UARCH_AM5X86,
@@ -267,6 +269,21 @@ struct uarch* get_uarch_from_cpuid_intel(uint32_t ef, uint32_t f, uint32_t em, u
   return arch;
 }
 
+struct uarch* get_uarch_from_cpuid_transmeta(uint32_t ef, uint32_t f, uint32_t em, uint32_t m, int s) {
+  struct uarch* arch = emalloc(sizeof(struct uarch));
+  // EF: Extended Family                                                             //
+  // F:  Family                                                                      //
+  // EM: Extended Model                                                              //
+  // M: Model                                                                        //
+  // S: Stepping                                                                     //
+  // ------------------------------------------------------------------------------- //
+  //                EF  F  EM   M   S                                                //
+  UARCH_START
+  CHECK_UARCH(arch, 0,  5,  0,  4,  3, "CRUSOE",            UARCH_CRUSOE, 	   130)
+  UARCH_END
+  return arch;
+}
+
 // Inspired in Todd Allen's decode_uarch_amd
 struct uarch* get_uarch_from_cpuid_amd(uint32_t ef, uint32_t f, uint32_t em, uint32_t m, int s) {
   struct uarch* arch = emalloc(sizeof(struct uarch));
@@ -435,6 +452,9 @@ struct uarch* get_uarch_from_cpuid(struct cpuInfo* cpu, uint32_t dump, uint32_t 
     }
     return get_uarch_from_cpuid_intel(ef, f, em, m, s);
   }
+  else if (cpu->cpu_vendor == CPU_VENDOR_TRANSMETA) {
+    return get_uarch_from_cpuid_transmeta(ef, f, em, m, s);
+  }
   else
     return get_uarch_from_cpuid_amd(ef, f, em, m, s);
 }
@@ -453,6 +473,8 @@ char* infer_cpu_name_from_uarch(struct uarch* arch) {
 
   if (arch->uarch == UARCH_P5)
     str = "Intel Pentium";
+  else if (arch->uarch == UARCH_CRUSOE)
+    str = "Transmeta Crusoe";
   else if (arch->uarch == UARCH_P5_MMX)
     str = "Intel Pentium MMX";
   else if (arch->uarch == UARCH_P6_PENTIUM_II)
@@ -531,6 +553,13 @@ bool choose_new_intel_logo_uarch(struct cpuInfo* cpu) {
     default:
       return false;
   }
+}
+
+bool choose_transmeta_crusoe_logo_uarch(struct cpuInfo* cpu) {
+  if (cpu->arch->uarch == UARCH_CRUSOE)
+      return true;
+  else
+      return false;
 }
 
 char* get_str_uarch(struct cpuInfo* cpu) {


### PR DESCRIPTION
I am aware of `contributing guidelines` 1, but I thought this might be helpful if you don't have a Crusoe at hand.

Initial support for Transmeta Crusoe CPU. Tested on TM5800 @ 1GHz.
Still trying to figure out how to read cache topology/set peak performance, but at least now my CPU is detected.

Upstream:
![cpufetch-upstream](https://github.com/Dr-Noob/cpufetch/assets/1027688/767cf417-b277-4f62-aff9-465dc8622c00)

With this PR:
![cpufetch-tm](https://github.com/Dr-Noob/cpufetch/assets/1027688/ef8a863a-5c4a-4009-b4c0-0e0637246f29)

`neofetch`, for reference:
![neofetch](https://github.com/Dr-Noob/cpufetch/assets/1027688/2895363c-bf33-4ea7-8387-e2fcbf70f689)

