### PR TITLE
Fix compilation when SVE2 is missing in action

### DIFF
--- a/src/arm/midr.c
+++ b/src/arm/midr.c
@@ -176,7 +176,9 @@ struct features* get_features_info(void) {
       printWarn("Unable to retrieve AT_HWCAP2 using getauxval");
     }
     else {
+#ifdef HWCAP2_SVE2
       feat->SVE2 = hwcaps & HWCAP2_SVE2;
+#endif // ifdef HWCAP2_SVE2
     }
   }
 #else


### PR DESCRIPTION
This little PR is intended to fix compilation failure on old Ubuntu 18.04.6 LTS (Bionic Beaver)

`cc -Wall -Wextra -pedantic -DARCH_ARM -Wno-unused-parameter -std=c99 -fstack-protector-all -O2 -Wfloat-equal -Wshadow -Wpointer-arith -Wstrict-prototypes  -c src/arm/sve.c -o sve.o
cc -Wall -Wextra -pedantic -DARCH_ARM -Wno-unused-parameter -std=c99 -fstack-protector-all -O2 -Wfloat-equal -Wshadow -Wpointer-arith -Wstrict-prototypes -DGIT_FULL_VERSION=\""v0.99-297-g0507"\" src/common/main.c src/common/cpu.c src/common/udev.c src/common/printer.c src/common/args.c src/common/global.c src/common/freq.c src/arm/midr.c src/arm/uarch.c src/common/soc.c src/arm/soc.c src/common/pci.c src/arm/udev.c sve.o -o cpufetch
src/arm/midr.c: In function ‘get_features_info’:
src/arm/midr.c:179:29: error: ‘HWCAP2_SVE2’ undeclared (first use in this function); did you mean ‘HWCAP_SVE’?
       feat->SVE2 = hwcaps & HWCAP2_SVE2;
                             ^~~~~~~~~~~
                             HWCAP_SVE
src/arm/midr.c:179:29: note: each undeclared identifier is reported only once for each function it appears in
Makefile:111: recipe for target 'cpufetch' failed
make: *** [cpufetch] Error 1
`
