### PR TITLE
fix: intel 8th gen code name

### DIFF
--- a/src/x86/uarch.c
+++ b/src/x86/uarch.c
@@ -255,7 +255,7 @@ struct uarch* get_uarch_from_cpuid_intel(uint32_t ef, uint32_t f, uint32_t em, u
   // CHECK_UARCH(arch, 0,  6,  8, 14,  9, ...) It is not possible to determine uarch only from CPUID dump (can be Kaby Lake or Amber Lake)
   // CHECK_UARCH(arch, 0,  6,  8, 14, 10, ...) It is not possible to determine uarch only from CPUID dump (can be Kaby Lake R or Coffee Lake U)
   CHECK_UARCH(arch, 0,  6,  8, 14, 11, "Whiskey Lake",      UARCH_WHISKEY_LAKE,     14) // wikichip
-  CHECK_UARCH(arch, 0,  6,  8, 14, 12, "Comet Lake",        UARCH_COMET_LAKE,       14) // wikichip
+  CHECK_UARCH(arch, 0,  6,  8, 14, 12, "Whiskey Lake",      UARCH_COMET_LAKE,       14) // wikichip
   CHECK_UARCH(arch, 0,  6,  8, 15,  8, "Sapphire Rapids",   UARCH_SAPPHIRE_RAPIDS,   7) // wikichip
   CHECK_UARCH(arch, 0,  6,  9,  6, NA, "Tremont",           UARCH_TREMONT,          10) // LX*
   CHECK_UARCH(arch, 0,  6,  9,  7, NA, "Alder Lake",        UARCH_ALDER_LAKE,       10) // instlatx64 (Alder Lake-S)


### PR DESCRIPTION
Intel Core i7-8565U core name has been reported as "Comet Lake", when it actually is "Whiskey Lake".

references:

* https://ark.intel.com/content/www/us/en/ark/products/149091/intel-core-i7-8565u-processor-8m-cache-up-to-4-60-ghz.html
* https://en.wikichip.org/wiki/intel/core_i7/i7-8565u

On a i7-8565U cpuid(1) reports:

    $ cpuid | tail -1
       (synth) = Intel Core i*-8000U (Whiskey Lake-U V0) [Kaby Lake] {Skylake}, 14nm+/14nm++