### PR TITLE
Add support for the Zca and Zcd RISCV extensions

### DIFF
--- a/src/riscv/riscv.c
+++ b/src/riscv/riscv.c
@@ -72,6 +72,8 @@ int parse_multi_letter_extension(struct extensions* ext, char* e) {
   SET_ISA_EXT_MAP("zicsr",       RISCV_ISA_EXT_ZICSR)
   SET_ISA_EXT_MAP("zifencei",    RISCV_ISA_EXT_ZIFENCEI)
   SET_ISA_EXT_MAP("zihpm",       RISCV_ISA_EXT_ZIHPM)
+  SET_ISA_EXT_MAP("zca",         RISCV_ISA_EXT_ZCA)
+  SET_ISA_EXT_MAP("zcd",         RISCV_ISA_EXT_ZCD)
   if(!maskset) {
     printBug("parse_multi_letter_extension: Unknown multi-letter extension: %s", multi_letter_extension);
     return -1;

--- a/src/riscv/riscv.h
+++ b/src/riscv/riscv.h
@@ -33,6 +33,8 @@ enum riscv_isa_ext_id {
   RISCV_ISA_EXT_ZICSR,
   RISCV_ISA_EXT_ZIFENCEI,
   RISCV_ISA_EXT_ZIHPM,
+  RISCV_ISA_EXT_ZCA,
+  RISCV_ISA_EXT_ZCD,
   RISCV_ISA_EXT_ID_MAX
 };
 
@@ -74,7 +76,9 @@ static const struct extension extension_list[] = {
   { RISCV_ISA_EXT_ZICNTR,      "(Zicntr) Base Counters and Timers" },
   { RISCV_ISA_EXT_ZICSR,       "(Zicsr) Control and Status Register" },
   { RISCV_ISA_EXT_ZIFENCEI,    "(Zifencei) Instruction-Fetch Fence" },
-  { RISCV_ISA_EXT_ZIHPM,       "(Zihpm) Hardware Performance Counters" }
+  { RISCV_ISA_EXT_ZIHPM,       "(Zihpm) Hardware Performance Counters" },
+  { RISCV_ISA_EXT_ZCA,         "(Zca) Integer Compressed Instructions" },
+  { RISCV_ISA_EXT_ZCD,         "(Zcd) Double FP Compressed Instructions" }
 };
 
 struct cpuInfo* get_cpu_info(void);


### PR DESCRIPTION
Add the Zca and Zcd extensions to avoid getting an error on the jh7110 SoC.

output:
``` text
                          #######                 SoC:                 StarFive VisionFive 2
                     ################.            Technology:          28nm
                ############   ###########        Microarchitecture:   U74
            ############           ##########.    Cores:               4 cores
       ############           #         ######    Max Frequency:       1.500 GHz
    ###########               #####         ##    Extensions:          rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
   #######.                   ##########           - (I) Integer Instruction Set
  ######            ###         *###########       - (M) Integer Multiplication and Division
  ######            #######.         ##########    - (A) Atomic Instructions
   #########        ############         ######    - (F) Single-Precision Floating-Point
     ###########.        ###########*         #    - (D) Double-Precision Floating-Point
         ############        ############          - (C) Compressed Instructions
   #         ############.       .###########      - (Zbb) Basic bit-manipulation
   ######         ###########         #########    - (Zba) Address Generation
   ##########         .######,            #####    - (Zicntr) Base Counters and Timers
      ############         ##.            #####.   - (Zicsr) Control and Status Register
           #########                   ########    - (Zifencei) Instruction-Fetch Fence
    ##         #####               ##########.     - (Zihpm) Hardware Performance Counters
    #######        #          ############         - (Zca) Integer Compressed Instructions
    ###########           ###########.             - (Zcd) Double FP Compressed Instructions
        ###########. ############                 Peak Performance:    6.00 GFLOP/s
            ################                    
```  