### PR TITLE
Add Temporary Support for apple M4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 cpufetch
 *.o
+.DS_Store

--- a/src/arm/midr.c
+++ b/src/arm/midr.c
@@ -514,7 +514,7 @@ struct cpuInfo* get_cpu_info_mach(struct cpuInfo* cpu) {
   else if(cpu_family == CPUFAMILY_ARM_EVEREST_SAWTOOTH ||
           cpu_family == CPUFAMILY_ARM_EVEREST_SAWTOOTH_2   ||
           cpu_family == CPUFAMILY_ARM_EVEREST_SAWTOOTH_PRO ||
-          cpu_family == CPUFAMILY_ARM_EVEREST_SAWTOOTH_MAX) {
+          cpu_family == CPUFAMILY_ARM_EVEREST_SAWTOOTH_MAX||cpu_family==CPUFAMILY_ARM_M4_TEMP) {
     fill_cpu_info_everest_sawtooth(cpu, pcores, ecores);
     cpu->soc = get_soc(cpu);
     cpu->peak_performance = get_peak_performance(cpu);

--- a/src/arm/soc.c
+++ b/src/arm/soc.c
@@ -1291,6 +1291,9 @@ struct system_on_chip* guess_soc_apple(struct system_on_chip* soc) {
       soc->vendor = SOC_VENDOR_UNKNOWN;
     }
   }
+  else if(cpu_family==CPUFAMILY_ARM_M4_TEMP){
+    fill_soc(soc, "M4", SOC_APPLE_M4,1);
+  }
   else {
     printBugCheckRelease("Found invalid cpu_family: 0x%.8X", cpu_family);
     soc->vendor = SOC_VENDOR_UNKNOWN;

--- a/src/arm/socs.h
+++ b/src/arm/socs.h
@@ -347,6 +347,10 @@ enum {
   SOC_APPLE_M3,
   SOC_APPLE_M3_PRO,
   SOC_APPLE_M3_MAX,
+  SOC_APPLE_M3_ULTRA,
+  SOC_APPLE_M4,
+  SOC_APPLE_M4_PRO,
+  SOC_APPLE_M4_MAX,
   // ALLWINNER
   SOC_ALLWINNER_A10,
   SOC_ALLWINNER_A13,
@@ -445,7 +449,7 @@ inline static VENDOR get_soc_vendor_from_soc(SOC soc) {
   else if(soc >= SOC_EXYNOS_3475 && soc <= SOC_EXYNOS_880) return SOC_VENDOR_EXYNOS;
   else if(soc >= SOC_MTK_MT5327 && soc <= SOC_MTK_MT6833V) return SOC_VENDOR_MEDIATEK;
   else if(soc >= SOC_SNAPD_QSD8650 && soc <= SOC_SNAPD_SC8280XP) return SOC_VENDOR_SNAPDRAGON;
-  else if(soc >= SOC_APPLE_M1 && soc <= SOC_APPLE_M3_MAX) return SOC_VENDOR_APPLE;
+  else if(soc >= SOC_APPLE_M1 && soc <= SOC_APPLE_M4_PRO) return SOC_VENDOR_APPLE;
   else if(soc >= SOC_ALLWINNER_A10 && soc <= SOC_ALLWINNER_R328) return SOC_VENDOR_ALLWINNER;
   else if(soc >= SOC_ROCKCHIP_3288 && soc <= SOC_ROCKCHIP_3588) return SOC_VENDOR_ROCKCHIP;
   else if(soc >= SOC_GOOGLE_TENSOR && soc <= SOC_GOOGLE_TENSOR_G3) return SOC_VENDOR_GOOGLE;

--- a/src/common/sysctl.h
+++ b/src/common/sysctl.h
@@ -29,7 +29,7 @@
 #define CPUFAMILY_ARM_EVEREST_SAWTOOTH_2   0xFA33415E
 #define CPUFAMILY_ARM_EVEREST_SAWTOOTH_PRO 0x5F4DEA93
 #define CPUFAMILY_ARM_EVEREST_SAWTOOTH_MAX 0x72015832
-
+#define CPUFAMILY_ARM_M4_TEMP 0x6F5129AC
 // For detecting different M1 types
 // NOTE: Could also be achieved detecting different
 // MIDR values (e.g., APPLE_CPU_PART_M1_ICESTORM_PRO)


### PR DESCRIPTION
I have no idea about the CPU_FAMily for M4 max  m4 pro and m3 ultra but I add the m4 support with information on my macbook air m4.